### PR TITLE
feat: add serde serialization as a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["sha3"] }
 merlin = { version = "3", default-features = false }
 bulletproofs = { git = "https://github.com/davidrusu/blst-bulletproofs.git", branch="bls12-381-curve" }
+serde = { version = "1.0.130", optional = true }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,12 @@ pub use error::Error;
 pub use mlsag::{DecoyInput, MlsagMaterial, MlsagSignature, TrueInput};
 pub use ringct::{Output, RingCtMaterial};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct RevealedCommitment {
     pub value: u64,

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -9,6 +9,10 @@ use tiny_keccak::{Hasher, Sha3};
 
 use crate::{Error, Result, RevealedCommitment};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct TrueInput {
     pub secret_key: Scalar,
@@ -36,6 +40,7 @@ impl TrueInput {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct DecoyInput {
     pub public_key: G1Affine,
@@ -52,6 +57,7 @@ impl DecoyInput {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MlsagMaterial {
     pub true_input: TrueInput,
@@ -230,6 +236,7 @@ impl MlsagMaterial {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MlsagSignature {
     pub c0: Scalar,

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -4,12 +4,16 @@ use merlin::Transcript;
 use rand_core::RngCore;
 use tiny_keccak::{Hasher, Sha3};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{Error, MlsagMaterial, MlsagSignature, Result, RevealedCommitment};
 pub(crate) const RANGE_PROOF_BITS: usize = 64; // note: Range Proof max-bits is 64. allowed are: 8, 16, 32, 64 (only)
                                                //       This limits our amount field to 64 bits also.
 pub(crate) const RANGE_PROOF_PARTIES: usize = 1; // The maximum number of parties that can produce an aggregated proof
 pub(crate) const MERLIN_TRANSCRIPT_LABEL: &[u8] = b"BLST_RINGCT";
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Output {
     pub public_key: G1Affine,
@@ -31,12 +35,14 @@ impl Output {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 struct RevealedOutputCommitment {
     pub public_key: G1Affine,
     pub revealed_commitment: RevealedCommitment,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Default)]
 pub struct RingCtMaterial {
     pub inputs: Vec<MlsagMaterial>,
@@ -236,6 +242,7 @@ fn gen_message_for_signing(
     msg
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct OutputProof {
     public_key: G1Affine,
@@ -265,6 +272,7 @@ impl OutputProof {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RingCtTransaction {
     pub mlsags: Vec<MlsagSignature>,


### PR DESCRIPTION
* derives serde Serialize/Deserialize for all types (except Error)
* package can be built with or without serde support

Error uses bulletproofs::ProofError which does not impl serialization.  (though the rest of bulletproofs does).

Some workarounds are possible, but I will leave that to another PR, if needed.