### PR TITLE
chore: remove unwanted println

### DIFF
--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -300,7 +300,6 @@ impl MlsagSignature {
             );
         }
 
-        println!("c': {:#?}", cprime);
         if self.c0 != cprime[0] {
             Err(Error::InvalidRingSignature)
         } else {


### PR DESCRIPTION
Just removes a debug println that is ugly when using the mint-repl.