### PR TITLE
feat: add generic contructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,12 @@ edition = "2021"
 
 [dependencies]
 # blstrs = "0.4.1"
-# blstrs = { git = "https://github.com/davidrusu/blstrs.git", branch="bulletproofs-fixes" }
-blstrs = { git = "https://github.com/dan-da/blstrs", branch = "blst_version_bump_pr" }
-
+blstrs = { git = "https://github.com/davidrusu/blstrs.git", branch="bulletproofs-fixes" }
 rand_core = "0.6.3"
 thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["sha3"] }
 merlin = { version = "3", default-features = false }
-bulletproofs = { git = "https://github.com/grumbach/blst-bulletproofs.git", branch="pump-blst-version" }
+bulletproofs = { git = "https://github.com/davidrusu/blst-bulletproofs.git", branch="bls12-381-curve" }
 serde = { version = "1.0.130", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,14 @@ edition = "2021"
 
 [dependencies]
 # blstrs = "0.4.1"
-blstrs = { git = "https://github.com/davidrusu/blstrs.git", branch="bulletproofs-fixes" }
+# blstrs = { git = "https://github.com/davidrusu/blstrs.git", branch="bulletproofs-fixes" }
+blstrs = { git = "https://github.com/dan-da/blstrs", branch = "blst_version_bump_pr" }
+
 rand_core = "0.6.3"
 thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["sha3"] }
 merlin = { version = "3", default-features = false }
-bulletproofs = { git = "https://github.com/davidrusu/blst-bulletproofs.git", branch="bls12-381-curve" }
+bulletproofs = { git = "https://github.com/grumbach/blst-bulletproofs.git", branch="pump-blst-version" }
 serde = { version = "1.0.130", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,14 +59,15 @@ pub fn hash_to_curve(p: G1Projective) -> G1Projective {
     G1Projective::hash_to_curve(&p.to_compressed(), DOMAIN, &[])
 }
 
-pub fn public_key(secret_key: Scalar) -> G1Projective {
-    G1Projective::generator() * secret_key
+pub fn public_key<S: Into<Scalar>>(secret_key: S) -> G1Projective {
+    G1Projective::generator() * secret_key.into()
 }
 
 /// returns KeyImage for the given public/secret key pair
 /// A key image is defined to be I = x * Hp(P)
-pub fn key_image(secret_key: Scalar) -> G1Projective {
-    hash_to_curve(public_key(secret_key)) * secret_key
+pub fn key_image<S: Into<Scalar>>(secret_key: S) -> G1Projective {
+    let sk = secret_key.into();
+    hash_to_curve(public_key(sk)) * sk
 }
 
 #[cfg(test)]

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -20,6 +20,13 @@ pub struct TrueInput {
 }
 
 impl TrueInput {
+    pub fn new<S: Into<Scalar>>(secret_key: S, revealed_commitment: RevealedCommitment) -> Self {
+        Self {
+            secret_key: secret_key.into(),
+            revealed_commitment,
+        }
+    }
+
     pub fn public_key(&self) -> G1Projective {
         crate::public_key(self.secret_key)
     }

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -14,19 +14,29 @@ pub(crate) const RANGE_PROOF_BITS: usize = 64; // note: Range Proof max-bits is 
 pub(crate) const RANGE_PROOF_PARTIES: usize = 1; // The maximum number of parties that can produce an aggregated proof
 pub(crate) const MERLIN_TRANSCRIPT_LABEL: &[u8] = b"BLST_RINGCT";
 
+/// Represents a Dbc's value.
+pub type Amount = u64;
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Output {
     pub public_key: G1Affine,
-    pub amount: u64,
+    pub amount: Amount,
 }
 
 impl Output {
+    pub fn new<G: Into<G1Affine>>(public_key: G, amount: Amount) -> Self {
+        Self {
+            public_key: public_key.into(),
+            amount,
+        }
+    }
+
     pub fn public_key(&self) -> G1Affine {
         self.public_key
     }
 
-    pub fn amount(&self) -> u64 {
+    pub fn amount(&self) -> Amount {
         self.amount
     }
 


### PR DESCRIPTION
- moved Amounts type in from `sn_dbc`
- generic constructors for `TrueInput` and `Output` so `sn_dbc` can use them with `blsttc` types