### PR TITLE
perf: create BulletProofGens before for loop

### DIFF
--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -205,11 +205,13 @@ impl RingCtMaterial {
     ) -> Result<Vec<OutputProof>> {
         let mut prover_ts = Transcript::new(MERLIN_TRANSCRIPT_LABEL);
 
+        let bp_gens = Self::bp_gens();
+
         revealed_output_commitments
             .iter()
             .map(|c| {
                 let (range_proof, commitment) = RangeProof::prove_single_with_rng(
-                    &Self::bp_gens(),
+                    &bp_gens,
                     &Self::pc_gens(),
                     &mut prover_ts,
                     c.revealed_commitment.value,
@@ -339,11 +341,12 @@ impl RingCtTransaction {
         }
 
         let mut prover_ts = Transcript::new(MERLIN_TRANSCRIPT_LABEL);
+        let bp_gens = RingCtMaterial::bp_gens();
 
         for output in self.outputs.iter() {
             // Verification requires a transcript with identical initial state:
             output.range_proof.verify_single(
-                &RingCtMaterial::bp_gens(),
+                &bp_gens,
                 &RingCtMaterial::pc_gens(),
                 &mut prover_ts,
                 &output.commitment,


### PR DESCRIPTION
BulletproofGens::new() has been appearing on flamegraphs using a substantial amount of time in benchmarks with multiple outputs.  This PR moves the new() call outside the for loop, thus reusing the same "gens" for multiple outputs.

I'm not yet certain this optimization is "Ok" in terms of security properties.  We should assure ourselves of that before merging.

But it is faster, and all tests pass, so there's that.   ;-)