### PR TITLE
chore: use published blstrs and decouple deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# blstrs = "0.4.1"
-blstrs = { git = "https://github.com/davidrusu/blstrs.git", branch="bulletproofs-fixes" }
-rand_core = "0.6.3"
 thiserror = "1"
 tiny-keccak = { version = "2.0", features = ["sha3"] }
-merlin = { version = "3", default-features = false }
-bulletproofs = { git = "https://github.com/davidrusu/blst-bulletproofs.git", branch="bls12-381-curve" }
+bulletproofs = { git = "https://github.com/dan-da/blst-bulletproofs.git", branch="blstrs_0_4_2_pr"}
 serde = { version = "1.0.130", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,14 @@ pub mod ringct;
 pub use bulletproofs;
 pub use bulletproofs::blstrs;
 pub use bulletproofs::group;
-pub use bulletproofs::rand_core;
+pub use bulletproofs::rand;
 #[cfg(feature = "serde")]
 pub use serde;
 
 use bulletproofs::{
     blstrs::{G1Projective, Scalar},
     group::{ff::Field, Group},
-    rand_core::RngCore,
+    rand::RngCore,
 };
 
 pub use error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,17 @@ pub mod error;
 pub mod mlsag;
 pub mod ringct;
 
-use blstrs::{
+// re-export deps used in our public API
+pub use bulletproofs;
+#[cfg(feature = "serde")]
+pub use serde;
+
+use bulletproofs::{
+    blstrs::{G1Projective, Scalar},
     group::{ff::Field, Group},
-    G1Projective, Scalar,
+    rand_core::RngCore,
 };
 
-pub use blstrs;
 pub use error::Error;
 pub use mlsag::{DecoyInput, MlsagMaterial, MlsagSignature, TrueInput};
 pub use ringct::{Output, RingCtMaterial};
@@ -33,7 +38,7 @@ impl RevealedCommitment {
     }
 
     /// Construct a revealed commitment from a value, generating a blinding randomly
-    pub fn from_value(value: u64, mut rng: impl rand_core::RngCore) -> Self {
+    pub fn from_value(value: u64, mut rng: impl RngCore) -> Self {
         Self {
             value,
             blinding: Scalar::random(&mut rng),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ pub mod ringct;
 
 // re-export deps used in our public API
 pub use bulletproofs;
+pub use bulletproofs::blstrs;
+pub use bulletproofs::group;
+pub use bulletproofs::rand_core;
 #[cfg(feature = "serde")]
 pub use serde;
 

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -1,7 +1,7 @@
 use bulletproofs::{
     blstrs::{G1Affine, G1Projective, Scalar},
     group::{ff::Field, Curve, Group, GroupEncoding},
-    rand_core::RngCore,
+    rand::RngCore,
     PedersenGens,
 };
 use tiny_keccak::{Hasher, Sha3};

--- a/src/mlsag.rs
+++ b/src/mlsag.rs
@@ -1,10 +1,9 @@
-use blstrs::{
-    group::GroupEncoding,
-    group::{ff::Field, Curve, Group},
-    G1Affine, G1Projective, Scalar,
+use bulletproofs::{
+    blstrs::{G1Affine, G1Projective, Scalar},
+    group::{ff::Field, Curve, Group, GroupEncoding},
+    rand_core::RngCore,
+    PedersenGens,
 };
-use bulletproofs::PedersenGens;
-use rand_core::RngCore;
 use tiny_keccak::{Hasher, Sha3};
 
 use crate::{Error, Result, RevealedCommitment};

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -4,7 +4,7 @@ use bulletproofs::{
     group::Curve,
     group::GroupEncoding,
     merlin::Transcript,
-    rand_core::{CryptoRng, RngCore},
+    rand::{CryptoRng, RngCore},
     BulletproofGens, PedersenGens, RangeProof,
 };
 use std::collections::BTreeSet;
@@ -403,7 +403,7 @@ mod tests {
 
     use bulletproofs::{
         group::{ff::Field, Curve, Group},
-        rand_core::OsRng,
+        rand::rngs::OsRng,
     };
 
     use crate::{DecoyInput, MlsagMaterial, TrueInput};

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -1,7 +1,12 @@
-use blstrs::{group::Curve, group::GroupEncoding, G1Affine, G1Projective, Scalar};
-use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
-use merlin::Transcript;
-use rand_core::RngCore;
+use bulletproofs::{
+    blstrs::{G1Affine, G1Projective, Scalar},
+    group::ff::Field,
+    group::Curve,
+    group::GroupEncoding,
+    merlin::Transcript,
+    rand_core::{CryptoRng, RngCore},
+    BulletproofGens, PedersenGens, RangeProof,
+};
 use std::collections::BTreeSet;
 use tiny_keccak::{Hasher, Sha3};
 
@@ -63,7 +68,7 @@ pub struct RingCtMaterial {
 impl RingCtMaterial {
     pub fn sign(
         &self,
-        mut rng: impl RngCore + rand_core::CryptoRng,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<(RingCtTransaction, Vec<RevealedCommitment>)> {
         // We need to gather a bunch of things for our message to sign.
         //   All public keys in all (input) rings
@@ -172,15 +177,17 @@ impl RingCtMaterial {
             .take(self.outputs.len() - 1)
             .collect();
 
+        // todo: replace fold() with sum() when supported in blstrs
         let input_sum: Scalar = revealed_pseudo_commitments
             .iter()
             .map(RevealedCommitment::blinding)
-            .sum();
+            .fold(Scalar::zero(), |sum, x| sum + x);
 
+        // todo: replace fold() with sum() when supported in blstrs
         let output_sum: Scalar = revealed_output_commitments
             .iter()
             .map(|r| r.revealed_commitment.blinding())
-            .sum();
+            .fold(Scalar::zero(), |sum, x| sum + x);
 
         let output_blinding_correction = input_sum - output_sum;
 
@@ -201,7 +208,7 @@ impl RingCtMaterial {
     fn output_range_proofs(
         &self,
         revealed_output_commitments: &[RevealedOutputCommitment],
-        mut rng: impl RngCore + rand_core::CryptoRng,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<Vec<OutputProof>> {
         let mut prover_ts = Transcript::new(MERLIN_TRANSCRIPT_LABEL);
 
@@ -394,8 +401,10 @@ impl RingCtTransaction {
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
-    use blstrs::group::{ff::Field, Curve, Group};
-    use rand_core::OsRng;
+    use bulletproofs::{
+        group::{ff::Field, Curve, Group},
+        rand_core::OsRng,
+    };
 
     use crate::{DecoyInput, MlsagMaterial, TrueInput};
 


### PR DESCRIPTION
-- Change 1 --

The idea is to give API consumers the option to use the exported crates
without needing explicit Cargo.toml entries.

This in turn decouples dependencies and reduces conflicts.

See rationale/discussion here:
https://github.com/rust-lang/api-guidelines/discussions/176

-- Change 2 --

We use blstrs from bulletproofs, which is now using the published
blstrs.  To use the published blstrs, we had to change ::sum()
calls for Scalar to use ::fold() instead.

We can change it back to ::sum() if/when published blstrs accepts
our PR for that.

Changes:
* re-export deps that are used in our public apis
* use deps from bulletproofs (blstrs, group, merlin, rand-core)
* replace ::sum() with ::fold() for Scalar

Cargo.toml:
* use blst-bulletproofs that re-exports public api deps
* remove deps that are re-exported in blst-bulletproofs

edit: once maidsafe/blst-bulletproofs is created and then published to crates.io, we can change that dep.  And then publish this crate also.