### PR TITLE
fix: verify pubkey are unique across inputs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,4 +18,6 @@ pub enum Error {
     TransactionMustHaveAnInput,
     #[error("key image is not unique across all transaction inputs")]
     KeyImageNotUniqueAcrossInputs,
+    #[error("public key is not unique across all transaction inputs")]
+    PublicKeyNotUniqueAcrossInputs,
 }

--- a/src/ringct.rs
+++ b/src/ringct.rs
@@ -376,6 +376,24 @@ impl RingCtTransaction {
             return Err(Error::KeyImageNotUniqueAcrossInputs);
         }
 
+        // Verify that each public_key is unique across all input mlsag
+        let pk_unique: BTreeSet<_> = self
+            .mlsags
+            .iter()
+            .flat_map(|m| {
+                m.public_keys()
+                    .iter()
+                    .map(|pk| pk.to_compressed())
+                    .collect::<Vec<[u8; 48]>>()
+            })
+            .collect();
+
+        let pk_count = self.mlsags.iter().map(|m| m.public_keys().len()).sum();
+
+        if pk_unique.len() != pk_count {
+            return Err(Error::PublicKeyNotUniqueAcrossInputs);
+        }
+
         let input_sum: G1Projective = self
             .mlsags
             .iter()


### PR DESCRIPTION
Issue: an sn_dbc test case was creating a Tx with
an input mlsag that had two duplicate public_keys.

It was determined this was occurring because
SpentbookNodeMock::random_decoy() returns a random set of decoys, which
in this case included the true input.

RingCtTransaction::verify() did not return any error for this
transaction and the test case passed when it should not have.

The fix is to validate that the public key is unique for every
possible input (true and decoys) across all mlsag.

Changes:
* add Error variant PublicKeyNotUniqueAcrossInputs
* verify that public keys are unique across all input mlsag